### PR TITLE
dev dependency as tolerable_risk

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -46,7 +46,7 @@ const run = async (): Promise<void> => {
     nodes.forEach(async node => {
       const response: GraphQlQueryResponseData = await octokit.graphql(`mutation MyMutation {
           dismissRepositoryVulnerabilityAlert(
-            input: {repositoryVulnerabilityAlertId: "", dismissReason: NOT_USED}
+            input: {repositoryVulnerabilityAlertId: "", dismissReason: tolerable_risk}
           )
         }`);
       core.info(JSON.stringify(response));


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

Gentle suggestion - If i had to choose between between our [best available status here](https://docs.github.com/en/rest/dependabot/alerts#update-a-dependabot-alert) :
- not_used
- tolerable_risk 

In the scenario of bulk dismissal - I would suggest `tolerable_risk` as this implies there is some condition where this vulnerable dependency might be used in the build pipeline (ex: webpack) vs flat out not being used at all.
